### PR TITLE
Remove portability bit for 32bit Snow Leopard

### DIFF
--- a/Formula/redis@5.0.6.rb
+++ b/Formula/redis@5.0.6.rb
@@ -6,9 +6,6 @@ class RedisAT506 < Formula
   head "https://github.com/antirez/redis.git", :branch => "unstable"
 
   def install
-    # Architecture isn't detected correctly on 32bit Snow Leopard without help
-    ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"
-
     system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}"
 
     %w[run db/redis log].each { |p| (var/p).mkpath }


### PR DESCRIPTION
Homebrew infrastructure does not support this anymore, get rid of the specific check as we are not needed to support this OS version.