### PR TITLE
Setting the latest MacOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,5 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
+          test-bot: false
           debug: true
-
-      - name: Run Homebrew tests
-        run: brew test-bot --skip-recursive-dependents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,7 @@ concurrency:
 
 jobs:
   brew-test-bot:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-11, macos-12]
+    runs-on: macOS-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,4 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          test-bot: false
           debug: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:
@@ -11,10 +11,6 @@ env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_CHANGE_ARCH_TO_ARM: 1
-
-concurrency:
-  group: "tests-${{ github.ref }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   brew-test-bot:

--- a/Formula/opensearch@2.8.0.rb
+++ b/Formula/opensearch@2.8.0.rb
@@ -1,9 +1,19 @@
-class OpensearchAT280 < Formula
+class Opensearch < Formula
   desc "Open source distributed and RESTful search engine"
   homepage "https://github.com/opensearch-project/OpenSearch"
   url "https://github.com/opensearch-project/OpenSearch/archive/2.8.0.tar.gz"
   sha256 "4ce1ab09853d58b382762093fe7804d2ddb051a420701f36c1fa2c0000496524"
   license "Apache-2.0"
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "676a1e754eb5208b119187b04f306a0c319317fb4c5bcafd0de5adcbeded1ff1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8a200919ee4784cd971b4406c2a86c5a56117627c881a94892e80e7d72d6aea8"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6d3a5b4193f5c36cb966e2a75e0fa06e418d9910c22953c5725e04ca27b4af3a"
+    sha256 cellar: :any_skip_relocation, ventura:        "af3d294756ce6fd7fe85c23eb5d68ac5d303af646529847a08240e5ff1f28952"
+    sha256 cellar: :any_skip_relocation, monterey:       "e38d4c3e64dcb71fbd80fa42b08e19bfc8d87e01b107de68a2ffee609b251c59"
+    sha256 cellar: :any_skip_relocation, big_sur:        "bf2054b28d2b42728ef916f1cdfe2fbfaa42e575c6b1bbacd54d4880b033fe08"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "13450d5d586141ee0ba83ff8bf07f8178bbc90f1b814aaeb17b6c81b44f013f9"
+  end
 
   depends_on "gradle" => :build
   depends_on "openjdk"


### PR DESCRIPTION
We should not be testing this against MacOS11 / 12, JAMF enforces latest MacOS version which is MacOS 13 Ventura